### PR TITLE
📅 Use `iframe` directive to embed Pythia calendar

### DIFF
--- a/portal/index.md
+++ b/portal/index.md
@@ -2,7 +2,7 @@
 
 :::{banner}
 :color: rgba(26, 100, 143, 0.9)
-:image: _static/images/backgrounds/pexels-jeff-stapleton-5792818.jpg
+:image: \_static/images/backgrounds/pexels-jeff-stapleton-5792818.jpg
 :caption: Photo by Jeff Stapleton from Pexels
 :class: dark-banner
 :::
@@ -34,7 +34,6 @@ _community-owned_, _geoscience-focused_, and _high-quality_.
         <img src="https://raw.githubusercontent.com/pangeo-data/pangeo/master/docs/_static/pangeo_simple_logo.svg" alt="Pangeo" height="22px">
     </a>
 </span>
-
 
 ## Start Learning
 
@@ -202,9 +201,9 @@ and [Outreach Meetings](https://docs.google.com/document/d/e/2PACX-1vQBAt5B24wig
 
 ### Meeting & Event Calendar
 
-<div class="iframe-4x3">
-    <iframe src="https://calendar.google.com/calendar/embed?src=c_4qpvf316afd9mv0ci7d2uiafog%40group.calendar.google.com" frameborder="0" scrolling="no"></iframe>
-</div>
+:::{iframe} https://calendar.google.com/calendar/embed?src=c_4qpvf316afd9mv0ci7d2uiafog%40group.calendar.google.com
+:::
+
 
 ## How to Cite
 
@@ -212,10 +211,9 @@ The material in Project Pythia is licensed for free and open consumption and reu
 
 To cite this project, please site our [NSF GEO OSE proposal](https://zenodo.org/record/8184298). Individual components of the project may be cited separately.
 
-> Rose, Brian E. J., Clyne, John, May, Ryan, Munroe, James, Snyder, Amelia, Eroglu, Orhan, & Tyle, Kevin. (2023). Collaborative Research: GEO OSE TRACK 2: Project Pythia and            Pangeo: Building an inclusive geoscience community through accessible, reusable, and reproducible workflows. Zenodo. https://doi.org/10.5281/zenodo.8184298
+> Rose, Brian E. J., Clyne, John, May, Ryan, Munroe, James, Snyder, Amelia, Eroglu, Orhan, & Tyle, Kevin. (2023). Collaborative Research: GEO OSE TRACK 2: Project Pythia and Pangeo: Building an inclusive geoscience community through accessible, reusable, and reproducible workflows. Zenodo. https://doi.org/10.5281/zenodo.8184298
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8184298.svg)](https://doi.org/10.5281/zenodo.8184298)
-
 
 ```{toctree}
 ---

--- a/portal/index.md
+++ b/portal/index.md
@@ -2,7 +2,7 @@
 
 :::{banner}
 :color: rgba(26, 100, 143, 0.9)
-:image: \_static/images/backgrounds/pexels-jeff-stapleton-5792818.jpg
+:image: _static/images/backgrounds/pexels-jeff-stapleton-5792818.jpg
 :caption: Photo by Jeff Stapleton from Pexels
 :class: dark-banner
 :::


### PR DESCRIPTION
This PR uses the `iframe` directive to embed the Google calendar into Pythia's home page.